### PR TITLE
Major refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,14 @@ categories = ["game-development", "accessibility", "gui"]
 repository = "https://github.com/nicopap/ui-navigation"
 homepage = "https://github.com/nicopap/ui-navigation"
 exclude = ["assets"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["render"] }
 non-empty-vec = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["render", "bevy_wgpu", "x11", "png", "bevy_gilrs" ] }
 bevy-ui-build-macros = "0.1"
+

--- a/Readme.md
+++ b/Readme.md
@@ -52,10 +52,10 @@ To respond to relevant user input, for example when the player pressed the
 `NavEvent` event queue:
 ```rust
 fn handle_nav_events(mut events: EventReader<NavEvent>, game: Res<Gameui>) {
-    use bevy_ui_navigation::{NavEvent::Caught, NavRequest::Action};
+    use bevy_ui_navigation::{NavEvent::NoChanges, NavRequest::Action};
     for event in events.iter() {
         match event {
-            Caught { from, request: Action } if from.first() == game.start_game_button => {
+            NoChanges { from, request: Action } if from.first() == game.start_game_button => {
                   // Start the game on "A" or "ENTER" button press
             }
             _ => {}
@@ -97,7 +97,7 @@ fn button_system(
 
 ### More complex use cases
 
-### With `NavFence`s
+### With `NavMenu`s
 
 Suppose you have a more complex game with menus sub-menus and sub-sub-menus etc.
 For example, in your everyday 2021 AAA game, to change the antialiasing you
@@ -109,11 +109,11 @@ In this case, you need to be capable of specifying which button in the previous
 menu leads to the next menu (for example, you would press the "Options" button
 in the game menu to access the options menu).
 
-For that, you need to use the `NavFence` component.
-1. First you need a "root" `NavFence`. This is a limit of the navigation
+For that, you need to use the `NavMenu` component.
+1. First you need a "root" `NavMenu`. This is a limit of the navigation
    algorithm (which may be fixed in the future)
 2. You also need the `Entity` value of your "Options" button
-3. You then add a `NavFence::reachable_from(options_button)` to the
+3. You then add a `NavMenu::reachable_from(options_button)` to the
    `NodeBundle` containing all the options menu `Focusable` entities.
 This may look like this:
 ```rust
@@ -131,7 +131,7 @@ let mut spawn_button = |bundle: &FocusableButtonBundle| {
 let options_button = spawn(&button);
 
 // Spawn the game menu                              !!vvvvvv!!
-let game_menu = commands.spawn(menu).insert(NavFence::root()).id();
+let game_menu = commands.spawn(menu).insert(NavMenu::root()).id();
 commads.entity(options_button).insert(Parent(game_menu));
 commads.entity(game_button).insert(Parent(game_menu));
 commads.entity(quit_button).insert(Parent(game_menu));
@@ -141,7 +141,7 @@ commads.entity(load_button).insert(Parent(game_menu));
 let options_menu = commands
       .spawn(menu)
       //              !!vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv!!
-      .insert(NavFence::reachable_from(options_button))
+      .insert(NavMenu::reachable_from(options_button))
       .id();
 commads.entity(graphics_option_button).insert(Parent(options_menu));
 commads.entity(audio_options_button).insert(Parent(options_menu));
@@ -154,7 +154,7 @@ access it by sending the `NavRequest::Action` when `options_button` is focused,
 or by sending a `NavRequest::FocusOn(input_options_button)`. 
 
 Specifically, navigation between `Focusable` entities will be constrained to
-other `Focusable` that are children of the `NavFence`. It creates a
+other `Focusable` that are children of the same `NavMenu`. It creates a
 self-contained menu.
 
 ### `NavRequest::FocusOn`
@@ -164,13 +164,13 @@ track of a lot of thing on the backend to make the navigation work as expected.
 But you can set the focused element to any arbitrary entity with the
 `NavRequest::FocusOn` request.
 
-### `NavFence` settings
+### `NavMenu` settings
 
-A `NavFence` doesn't only define menu-to-menu navigation, but it also gives you
+A `NavMenu` doesn't only define menu-to-menu navigation, but it also gives you
 finner-grained control on how navigation is handled within a menu.
-`NavFence::{looping, closed}` controls whether or not going left from the
-leftmost element goes to the rightmost and vis-versa. `NavFence::sequence`
-sets the menu as a sort of global control menu. It catches `NavRequest::MenuMove`
+`NavMenu::{cycle, closed}` controls whether or not going left from the
+leftmost element goes to the rightmost and vis-versa. `NavMenu::scope`
+sets the menu as a sort of global control menu. It catches `NavRequest::ScopeMove`
 requests even when the focused entity is in another sub-menu reachable from this
 menu. This behaves like you would expect a tabbed menu to behave. See the
 ["ultimate" menu navigation
@@ -198,13 +198,11 @@ for a demonstration.
 - [X] Minor refactor of `resolve` function + Add FocusableButtonBundle to
       examples to simplify them greatly
 - [ ] Replace most calls to `.iter().find(…)` for child non_inert by checking
-      the `NavFence`'s `non_inert_child` rather than `query.nav_fences`. This
+      the `NavMenu`'s `non_inert_child` rather than `query.nav_menus`. This
       fixes the most likely hotspot which is the recursive function
       `children_focusables`.
 - [ ] Descend the hierarchy on Next and Previous (requires non_inert_child
       otherwise it's going to be very difficult to implement)
-- [ ] Add mouse support
-- [ ] Even more lööps (`North`/`South` and `East`/`West` locked)
 
 # License
 

--- a/examples/flat_2d_across_nodes.rs
+++ b/examples/flat_2d_across_nodes.rs
@@ -2,7 +2,7 @@ use bevy::input::{keyboard::KeyboardInput, ElementState};
 use bevy::prelude::*;
 
 use bevy_ui_navigation::{
-    Direction, Focusable, Focused, NavEvent, NavFence, NavRequest, NavigationPlugin,
+    Direction, Focusable, Focused, NavEvent, NavMenu, NavRequest, NavigationPlugin,
 };
 
 /// Shows how navigation is supported even between siblings separated by a
@@ -106,14 +106,14 @@ fn setup(mut commands: Commands, button_materials: Res<ButtonMaterials>) {
         // The `Focusable`s buttons are not direct siblings, we can navigate through
         // them beyond direct hierarchical relationships.
         //
-        // To prevent this, we can add a `NavFence` as a sort of boundary
+        // To prevent this, we can add a `NavMenu` as a sort of boundary
         // between different sets of `Focusable`s. This requires having an
-        // englobing `NavFence` that contains all other `NavFence`s or
+        // englobing `NavMenu` that contains all other `NavMenu`s or
         // `Focusable`s
         //
-        // YOU MUSTE ADD A NavFence enclosing ALL Focusable and ALL NavFence (but
+        // YOU MUSTE ADD A NavMenu enclosing ALL Focusable and ALL NavMenu (but
         // themselves) Subtile broken behavior will ensure otherwise
-        .insert(NavFence::root())
+        .insert(NavMenu::root())
         .with_children(|commands| {
             for i in 0..3 {
                 let style = Style {
@@ -143,8 +143,8 @@ fn setup(mut commands: Commands, button_materials: Res<ButtonMaterials>) {
             commands
                 .spawn_bundle(bundle)
                 // We don't want to be able to access the pink square, so we
-                // add a `NavFence` as boundary
-                .insert(NavFence::root())
+                // add a `NavMenu` as boundary
+                .insert(NavMenu::root())
                 .with_children(|commands| {
                     spawn_button(commands, &button_materials);
                     spawn_button(commands, &button_materials);

--- a/examples/nested_menu_1d_nav.rs
+++ b/examples/nested_menu_1d_nav.rs
@@ -1,7 +1,7 @@
 use bevy::input::{keyboard::KeyboardInput, ElementState};
 use bevy::prelude::*;
 
-use bevy_ui_navigation::{Direction, Focusable, NavEvent, NavFence, NavRequest, NavigationPlugin};
+use bevy_ui_navigation::{Direction, Focusable, NavEvent, NavMenu, NavRequest, NavigationPlugin};
 
 /// This example demonstrates a more complex menu system where you navigate
 /// through menus and go to submenus using the `Action` and `Cancel`
@@ -50,7 +50,7 @@ impl Gameui {
     }
 }
 
-fn query_bad_stuff(query: Query<(Entity, &NavFence, &Focusable), Changed<Focusable>>) {
+fn query_bad_stuff(query: Query<(Entity, &NavMenu, &Focusable), Changed<Focusable>>) {
     if !query.is_empty() {
         println!("BAD STUFF: {:?}", query.iter().collect::<Vec<_>>());
     }
@@ -131,12 +131,13 @@ fn handle_nav_events(
     mut requests: EventWriter<NavRequest>,
     game: Res<Gameui>,
 ) {
+    use NavRequest::Action;
     for event in events.iter() {
         println!("{:?}", event);
         match event {
-            NavEvent::Caught {
+            NavEvent::NoChanges {
                 from,
-                request: NavRequest::Action,
+                request: Action,
             } if game.from.contains(from.first()) => requests.send(NavRequest::FocusOn(game.to)),
             _ => {}
         }
@@ -193,13 +194,13 @@ fn setup(mut commands: Commands, materials: Res<Materials>, mut game: ResMut<Gam
 
     commands
         .spawn_bundle(bundle)
-        .insert(NavFence::root())
+        .insert(NavMenu::root())
         .with_children(|commands| {
             let mut next_menu_button: Option<Entity> = None;
             for j in 0..5 {
                 commands
                     .spawn_bundle(menu(&materials))
-                    .insert(NavFence::new(next_menu_button).looping())
+                    .insert(NavMenu::new(next_menu_button).cycling())
                     .with_children(|commands| {
                         for i in 0..4 {
                             let mut button = commands.spawn_bundle(button(&materials));

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,20 +2,30 @@ use bevy::ecs::entity::Entity;
 use bevy::math::Vec2;
 use non_empty_vec::NonEmpty;
 
+/// Requests to send to the navigation system to update focus
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum NavRequest {
+    /// Move in 2d in provided direction
     Move(Direction),
-    MenuMove(MenuDirection),
+    /// Move within the encompassing [`NavMenu::scope`](crate::NavMenu::scope)
+    ScopeMove(ScopeDirection),
+    /// Enter submenu if any [`NavMenu::reachable_from`](crate::NavMenu::reachable_from)
+    /// the currently focused entity.
     Action,
+    /// Leave this submenu to enter the one it is [`reachable_from`](crate::NavMenu::reachable_from)
     Cancel,
+    /// Move the focus to any arbitrary [`Focusable`](crate::Focusable) entity
     FocusOn(Entity),
 }
 
+/// Direction for movement in [`NavMenu::scope`](crate::NavMenu::scope) menus.
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub enum MenuDirection {
+pub enum ScopeDirection {
     Next,
     Previous,
 }
+
+/// 2d direction to move in normal menus
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Direction {
     South,
@@ -45,6 +55,11 @@ impl Direction {
     }
 }
 
+/// Events emitted by the navigation system.
+///
+/// Useful if you want to react to [`NavEvent::NoChanges`] event, for example
+/// when a "start game" button is focused and the [`NavRequest::Action`] is
+/// pressed.
 #[derive(Debug, Clone)]
 pub enum NavEvent {
     /// Focus changed
@@ -57,14 +72,15 @@ pub enum NavEvent {
     /// Both lists are ascending, meaning that the focused and newly
     /// focused elements are the first of their respective vectors.
     ///
-    /// [[NonEmpty]] enables you to safely check `to.first()` or `from.first()`
+    /// [`NonEmpty`] enables you to safely check `to.first()` or `from.first()`
     /// without returning an option. It is guaranteed that there is at least
     /// one element.
     FocusChanged {
         to: NonEmpty<Entity>,
         from: NonEmpty<Entity>,
     },
-    Caught {
+    /// The [`NavRequest`] didn't lead to any change in focus.
+    NoChanges {
         from: NonEmpty<Entity>,
         request: NavRequest,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! A navigation system. Use [`NavigationPlugin`] to get it working
+//!
+//! See [the RFC](https://github.com/nicopap/rfcs/blob/ui-navigation/rfcs/41-ui-navigation.md)
+//! for a deep explanation on how this works.
 // TODO: review all uses of `.unwrap()`!
 // Notes on the structure of this file:
 //
@@ -14,89 +18,101 @@ use std::num::NonZeroUsize;
 use bevy::ecs::system::{QuerySingleError, SystemParam};
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
-use non_empty_vec::NonEmpty;
+pub use non_empty_vec::NonEmpty;
 
-pub use crate::events::{Direction, MenuDirection, NavEvent, NavRequest};
+pub use crate::events::{Direction, NavEvent, NavRequest, ScopeDirection};
 
 #[derive(SystemParam)]
 struct NavQueries<'w, 's> {
     children: Query<'w, 's, &'static Children>,
     parents: Query<'w, 's, &'static Parent>,
     focusables: Query<'w, 's, (Entity, &'static Focusable), With<Focusable>>,
-    nav_fences: Query<'w, 's, (Entity, &'static NavFence), With<NavFence>>,
+    menus: Query<'w, 's, (Entity, &'static NavMenu), With<NavMenu>>,
     transform: Query<'w, 's, &'static GlobalTransform>,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq)]
-enum FocusState {
+pub enum FocusState {
+    /// An entity that was previously [`Active`](FocusState::Active) from a branch of
+    /// the menu tree that is currently not _focused_. When focus comes back to
+    /// the [`NavMenu`] containing this [`Focusable`], the `Dormant` element
+    /// will be the [`Focused`](FocusState::Focused) entity.
     Dormant,
+    /// The currently highlighted/used entity, there is only a signle _focused_
+    /// entity.
     Focused,
+    /// The path through the menu tree to the current [`Focused`](FocusState::Focused)
+    /// entity. They are the [`Focusable`]s from previous menus that were
+    /// activated in order to reach the [`NavMenu`] containing the currently
+    /// _focused_ element.
     Active,
+    /// None of the above: This [`Focusable`] is neither `Dormant`, `Focused`
+    /// or `Active`.
     Inert,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq)]
-enum NavSetting {
-    /// 2d movement that doesn't loop
+enum MenuSetting {
+    /// 2d movement that doesn't cycle
     ClosedXY,
-    /// 2d movement looping on both axis
-    LoopXY,
-    /// Next/Previous menu without loop
-    ClosedSequence,
-    /// Next/Previous menu with loop
-    LoopSequence,
+    /// 2d movement cycle on both axis
+    CycleXY,
+    /// Next/Previous menu without cycle
+    ClosedScope,
+    /// Next/Previous menu with cycle
+    CycleScope,
 }
-impl NavSetting {
+impl MenuSetting {
     fn closed(self) -> Self {
-        use NavSetting::*;
+        use MenuSetting::*;
         match self {
-            ClosedXY | LoopXY => ClosedXY,
-            ClosedSequence | LoopSequence => ClosedSequence,
+            ClosedXY | CycleXY => ClosedXY,
+            ClosedScope | CycleScope => ClosedScope,
         }
     }
-    fn looping(self) -> Self {
-        use NavSetting::*;
+    fn cycling(self) -> Self {
+        use MenuSetting::*;
         match self {
-            ClosedXY | LoopXY => LoopXY,
-            ClosedSequence | LoopSequence => LoopSequence,
+            ClosedXY | CycleXY => CycleXY,
+            ClosedScope | CycleScope => CycleScope,
         }
     }
-    fn sequence(self) -> Self {
-        use NavSetting::*;
+    fn scope(self) -> Self {
+        use MenuSetting::*;
         match self {
-            ClosedSequence | ClosedXY => ClosedSequence,
-            LoopSequence | LoopXY => LoopSequence,
+            ClosedScope | ClosedXY => ClosedScope,
+            CycleScope | CycleXY => CycleScope,
         }
     }
-    fn loops(&self) -> bool {
-        use NavSetting::*;
+    fn cycles(&self) -> bool {
+        use MenuSetting::*;
         match self {
-            LoopSequence | LoopXY => true,
-            ClosedSequence | ClosedXY => false,
+            CycleScope | CycleXY => true,
+            ClosedScope | ClosedXY => false,
         }
     }
     fn is_2d(&self) -> bool {
-        !self.is_sequence()
+        !self.is_scope()
     }
-    fn is_sequence(&self) -> bool {
-        use NavSetting::*;
+    fn is_scope(&self) -> bool {
+        use MenuSetting::*;
         match self {
-            ClosedSequence | LoopSequence => true,
-            ClosedXY | LoopXY => false,
+            ClosedScope | CycleScope => true,
+            ClosedXY | CycleXY => false,
         }
     }
 }
 
-/// A "scope" that isolate children [[Focusable]]s from other focusables and
+/// A menu that isolate children [`Focusable`]s from other focusables and
 /// specify navigation method within itself.
 ///
-/// A `NavFence` can be used to:
+/// A `NavMenu` can be used to:
 /// * Prevent navigation from one specific submenu to another
-/// * Specify the loop directions of navigation (going left when focusing on a
-///   leftmost [[Focusable]] may go to the rightmost `Focusable`)
-/// * Specify "tabbed menus" (TODO: name TBD) such that pressing
-///   [[NavRequest::Next]] or [[NavRequest::Previous]] in a [[Focusable]]
-///   nested within this `NavFence` will navigate this menu.
+/// * Specify the cycle directions of navigation (going left when focusing on a
+///   leftmost [`Focusable`] may go to the rightmost `Focusable`)
+/// * Specify "scope menus"  such that a [`NavRequest::ScopeMove`] emitted when
+///   the focused element is a [`Focusable`] nested within this `NavMenu`
+///   will navigate this menu.
 /// * Specify _submenus_ and specify from where those submenus are reachable
 ///
 /// # Important
@@ -105,18 +121,18 @@ impl NavSetting {
 ///
 /// 1. There should be **no cycles in the navigation graph**, ie:
 ///    You must ensure this doesn't create a cycle. You shouldn't be able
-///    to reach `NavFence` X from [[Focusable]] Y if there is a path from
-///    `NavFence` X to `Focusable` Y.
-/// 2. There must be **at least one child [[Focusable]]** in the ui graph for each
-///    `NavFence` when sending a [[NavRequest]]
+///    to reach `NavMenu` X from [`Focusable`] Y if there is a path from
+///    `NavMenu` X to `Focusable` Y.
+/// 2. There must be **at least one child [`Focusable`]** in the ui graph for each
+///    `NavMenu` when sending a [`NavRequest`]
 #[derive(Debug, Component, Clone)]
-pub struct NavFence {
-    /// The `Focusable` of the scoping `NavFence` that links to this
-    /// `NavFence` (None if this `NavFence` is the navigation graph root)
+pub struct NavMenu {
+    /// The [`Focusable`] in the `NavMenu` that links to this
+    /// `NavMenu` (`None` if this `NavMenu` is the menu graph root)
     focus_parent: Option<Entity>,
 
-    /// How we expect the user to move between [[Focusable]]s within this fence
-    setting: NavSetting,
+    /// How we want the user to move between [`Focusable`]s within this menu
+    setting: MenuSetting,
     // TODO: (for caching and not having to discover all contained focusables
     // just to find the one we are interested in)
     // The child of interest
@@ -125,70 +141,69 @@ pub struct NavFence {
     // every time we need to find the relevant child.
     // non_inert_child: CacheOption<Entity>,
 }
-impl NavFence {
-    /// Prefer [[NavFence::reachable_from]] and [[NavFence::root]] to this
+impl NavMenu {
+    /// Prefer [`NavMenu::reachable_from`] and [`NavMenu::root`] to this
     ///
     /// `new` is useful to programmatically set the parent if you have an
     /// optional value. This saves you from a `match focus_parent`.
     pub fn new(focus_parent: Option<Entity>) -> Self {
-        NavFence {
+        NavMenu {
             focus_parent,
-            setting: NavSetting::ClosedXY,
+            setting: MenuSetting::ClosedXY,
         }
     }
 
-    /// Set this fence as having no parents
+    /// Set this menu as having no parents
     pub fn root() -> Self {
-        NavFence {
+        NavMenu {
             focus_parent: None,
-            setting: NavSetting::ClosedXY,
+            setting: MenuSetting::ClosedXY,
         }
     }
 
-    /// Set this fence as closed (no looping)
+    /// Set this menu as closed (no cycling)
     pub fn closed(mut self) -> Self {
         self.setting = self.setting.closed();
         self
     }
 
-    /// Set this fence as looping
+    /// Set this menu as cycling
     ///
     /// ie: going left from the leftmost element goes to the rightmost element
-    pub fn looping(mut self) -> Self {
-        self.setting = self.setting.looping();
+    pub fn cycling(mut self) -> Self {
+        self.setting = self.setting.cycling();
         self
     }
 
-    // Set this fence as being a sequence menu
-    //
-    // Meaning: controlled with [[NavRequest::Next]] and
-    // [[NavRequest::Previous]]
-    pub fn sequence(mut self) -> Self {
-        self.setting = self.setting.sequence();
-        self
-    }
-
-    // Should this be `unsafe`? Kinda annoying to have such an important part
-    // of the API behind `unsafe`.
-    /// Set this fence as reachable from a given [[Focusable]]
+    /// Set this menu as a scope menu
     ///
-    /// When requesting [[NavRequest::Action]] when `focusable` is focused, the
-    /// focus will be changed to a focusable within this fence.
+    /// Meaning: controlled with [`NavRequest::ScopeMove`] even when the
+    /// focused element is not in this menu, but in a submenu reachable from
+    /// this one.
+    pub fn scope(mut self) -> Self {
+        self.setting = self.setting.scope();
+        self
+    }
+
+    /// Set this menu as reachable from a given [`Focusable`]
+    ///
+    /// When requesting [`NavRequest::Action`] when `focusable` is focused, the
+    /// focus will be changed to a focusable within this menu.
     ///
     /// # Important
     ///
     /// You must ensure this doesn't create a cycle. Eg: you shouldn't be able
-    /// to reach `NavFence` X from `Focusable` Y if there is a path from
-    /// `NavFence` X to `Focusable` Y.
+    /// to reach `NavMenu` X from `Focusable` Y if there is a path from
+    /// `NavMenu` X to `Focusable` Y.
     pub fn reachable_from(focusable: Entity) -> Self {
-        NavFence {
+        NavMenu {
             focus_parent: Some(focusable),
-            setting: NavSetting::ClosedXY,
+            setting: MenuSetting::ClosedXY,
         }
     }
 }
 
-/// An [[Entity]] that can be navigated to using the ui navigation system.
+/// An [`Entity`] that can be navigated to using the ui navigation system.
 #[derive(Component, Clone, Copy)]
 pub struct Focusable {
     focus_state: FocusState,
@@ -206,12 +221,17 @@ impl fmt::Debug for Focusable {
     }
 }
 impl Focusable {
+    /// The state of this `Focusable`
+    pub fn state(&self) -> FocusState {
+        self.focus_state
+    }
+
     /// This `Focusable` is the unique _focused_ element
     ///
     /// All navigation requests start from it.
     ///
-    /// To set an arbitrary [[Focusable]] to _focused_, you should send a
-    /// [[NavRequest::Focus]] request.
+    /// To set an arbitrary [`Focusable`] to _focused_, you should send a
+    /// [`NavRequest::FocusOn`] request.
     pub fn is_focused(&self) -> bool {
         self.focus_state == FocusState::Focused
     }
@@ -229,8 +249,8 @@ impl Focusable {
     ///
     /// When focus leaves a specific `Focusable` without being acquired by a
     /// sibling, it becomes _dormant_. When focus comes back to the
-    /// encompassing [[NavFence]], the _focused_ element will be the _dormant_
-    /// element within the fence.
+    /// encompassing [`NavMenu`], the _focused_ element will be the _dormant_
+    /// element within the menu.
     pub fn is_dormant(&self) -> bool {
         self.focus_state == FocusState::Dormant
     }
@@ -246,18 +266,18 @@ impl Focusable {
     }
 }
 
-/// The currently _focused_ [[Focusable]]
+/// The currently _focused_ [`Focusable`]
 ///
 /// You cannot edit it or create new `Focused` component. To set an arbitrary
-/// [[Focusable]] to _focused_, you should send a [[NavRequest::FocusOn]]
+/// [`Focusable`] to _focused_, you should send a [`NavRequest::FocusOn`]
 /// request.
 ///
-/// This [[Component]] is useful if you need to query for the _currently
-/// focused_ element using a `Query<Entity, With<Focused>>` [[SystemParam]] for
+/// This [`Component`] is useful if you need to query for the _currently
+/// focused_ element using a `Query<Entity, With<Focused>>` [`SystemParam`] for
 /// example.
 ///
-/// You can also check if a [[Focusable]] is _focused_ using
-/// [[Focusable::is_focused]].
+/// You can also check if a [`Focusable`] is _focused_ using
+/// [`Focusable::is_focused`].
 #[derive(Component)]
 #[non_exhaustive]
 pub struct Focused;
@@ -267,7 +287,7 @@ pub struct Focused;
 fn resolve_2d<'a, 'b, 'c>(
     focused: Entity,
     direction: Direction,
-    loops: bool,
+    cycles: bool,
     siblings: &'a [Entity],
     transform: &'b Query<&'c GlobalTransform>,
 ) -> Option<&'a Entity> {
@@ -280,7 +300,7 @@ fn resolve_2d<'a, 'b, 'c>(
     });
     let closest = max_by_in_iter(closest, |s| -focused_pos.distance_squared(pos_of(**s).xy()));
     match closest {
-        None if loops => {
+        None if cycles => {
             let direction = direction.opposite();
 
             let furthest = siblings.iter().filter(|sibling| {
@@ -290,13 +310,16 @@ fn resolve_2d<'a, 'b, 'c>(
                 let pos = pos_of(**s);
 
                 // In a grid, ideally if we are at the leftmost tile and press
-                // left, we loop back ON THE SAME ROW to rightmost tile. To do
+                // left, we cycle back ON THE SAME ROW to rightmost tile. To do
                 // this, we minimize first `axial_diff` then we care about
                 // `focused_pos`.
                 //
                 // FIXME: this is unoptimal because a very tinny pixel missalignment
-                // will cause the loop to favor a different entity than
+                // will cause the cycle to favor a different entity than
                 // probably expected.
+                // Solution is to look at closest focusable in same direction,
+                // but with the X/Y coordinate (corresponding to the direction)
+                // set to very low or very high.
                 let axial_diff = if matches!(direction, South | North) {
                     (pos.x - focused_pos.x).abs()
                 } else {
@@ -321,10 +344,10 @@ fn max_by_in_iter<U, T: PartialOrd>(
 }
 
 /// Returns the next or previous entity based on `direction`
-fn resolve_sequence(
+fn resolve_scope(
     focused: Entity,
-    direction: MenuDirection,
-    loops: bool,
+    direction: ScopeDirection,
+    cycles: bool,
     siblings: &NonEmpty<Entity>,
 ) -> Option<&Entity> {
     let focused_index = siblings
@@ -332,7 +355,7 @@ fn resolve_sequence(
         .enumerate()
         .find(|e| *e.1 == focused)
         .map(|e| e.0)?;
-    let new_index = resolve_index(focused_index, loops, direction, siblings.len().get() - 1);
+    let new_index = resolve_index(focused_index, cycles, direction, siblings.len().get() - 1);
     new_index.and_then(|i| siblings.get(i))
 }
 
@@ -352,24 +375,26 @@ fn resolve(
     assert!(
         !from.contains(&focused),
         "Navigation graph cycle detected! This panic has prevented a stack overflow, \
-        please check usages of `NavFence::reachable_from`"
+        please check usages of `NavMenu::reachable_from`"
     );
 
     let mut from = (from, focused).into();
 
-    macro_rules! or_caught {
+    macro_rules! or_none {
         ($to_match:expr) => {
             match $to_match {
                 Some(x) => x,
-                None => return NavEvent::Caught { from, request },
+                None => return NavEvent::NoChanges { from, request },
             }
         };
     }
     match request {
         Move(direction) => {
-            let (parent, loops) = match parent_nav_fence(focused, queries) {
-                Some(val) if !val.1.setting.is_2d() => return NavEvent::Caught { from, request },
-                Some(val) => (Some(val.0), val.1.setting.loops()),
+            let (parent, cycles) = match parent_menu(focused, queries) {
+                Some(val) if !val.1.setting.is_2d() => {
+                    return NavEvent::NoChanges { from, request }
+                }
+                Some(val) => (Some(val.0), val.1.setting.cycles()),
                 None => (None, true),
             };
             let siblings = match parent {
@@ -382,36 +407,36 @@ fn resolve(
                     panic!("There must be at least one `Focusable` when sending a `NavRequest`!")
                 }
             };
-            let to = resolve_2d(focused, direction, loops, &siblings, &queries.transform);
-            let to = or_caught!(to);
+            let to = resolve_2d(focused, direction, cycles, &siblings, &queries.transform);
+            let to = or_none!(to);
             NavEvent::focus_changed(*to, from)
         }
         Cancel => {
-            let to = or_caught!(parent_nav_fence(focused, queries));
-            let to = or_caught!(to.1.focus_parent);
+            let to = or_none!(parent_menu(focused, queries));
+            let to = or_none!(to.1.focus_parent);
             from.push(to);
             NavEvent::focus_changed(to, from)
         }
         Action => {
-            let child_nav_fence = queries
-                .nav_fences
+            let child_menu = queries
+                .menus
                 .iter()
                 .find(|e| e.1.focus_parent == Some(focused));
-            let (child_nav_fence, _) = or_caught!(child_nav_fence);
-            let to = children_focusables(child_nav_fence, queries);
+            let (child_menu, _) = or_none!(child_menu);
+            let to = children_focusables(child_menu, queries);
             let to = non_inert_within(&to, queries);
             let to = (*to, from.clone().into()).into();
             NavEvent::FocusChanged { to, from }
         }
-        MenuMove(menu_dir) => {
-            let (parent, nav_fence) = or_caught!(parent_nav_fence(focused, queries));
+        ScopeMove(scope_dir) => {
+            let (parent, menu) = or_none!(parent_menu(focused, queries));
             let siblings = children_focusables(parent, queries);
-            if !nav_fence.setting.is_sequence() {
-                let focused = nav_fence.focus_parent.unwrap();
+            if !menu.setting.is_scope() {
+                let focused = menu.focus_parent.unwrap();
                 resolve(focused, request, queries, from.into())
             } else {
-                let loops = nav_fence.setting.loops();
-                let to = or_caught!(resolve_sequence(focused, menu_dir, loops, &siblings));
+                let cycles = menu.setting.cycles();
+                let to = or_none!(resolve_scope(focused, scope_dir, cycles, &siblings));
                 NavEvent::focus_changed(*to, from)
             }
         }
@@ -424,7 +449,7 @@ fn resolve(
     }
 }
 
-/// Listen to [[NavRequest]] and update the state of [[Focusable]] entities if
+/// Listen to [`NavRequest`] and update the state of [`Focusable`] entities if
 /// relevant.
 fn listen_nav_requests(
     focused: Query<Entity, With<Focused>>,
@@ -435,7 +460,7 @@ fn listen_nav_requests(
 ) {
     // TODO: this most likely breaks when there is more than a single event
     // When no `Focused` found, should take a direct child of a
-    // `NavFence.focus_parent == None`
+    // `NavMenu.focus_parent == None`
     for request in requests.iter() {
         // TODO: This code needs cleanup
         let focused_id = focused.get_single().unwrap_or_else(|err| {
@@ -468,28 +493,28 @@ fn listen_nav_requests(
     }
 }
 
-/// The [[NavFence]] containing `focusable`, if any
-fn parent_nav_fence(focusable: Entity, queries: &NavQueries) -> Option<(Entity, NavFence)> {
+/// The [`NavMenu`] containing `focusable`, if any
+fn parent_menu(focusable: Entity, queries: &NavQueries) -> Option<(Entity, NavMenu)> {
     let Parent(parent) = queries.parents.get(focusable).ok()?;
-    match queries.nav_fences.get(*parent) {
-        Ok(nav_fence) => Some((*parent, nav_fence.1.clone())),
-        Err(_) => parent_nav_fence(*parent, queries),
+    match queries.menus.get(*parent) {
+        Ok(menu) => Some((*parent, menu.1.clone())),
+        Err(_) => parent_menu(*parent, queries),
     }
 }
 
-/// All sibling [[Focusable]]s within a single [[NavFence]]
-fn children_focusables(nav_fence: Entity, queries: &NavQueries) -> NonEmpty<Entity> {
-    let ret = children_focusables_helper(nav_fence, queries);
+/// All sibling [`Focusable`]s within a single [`NavMenu`]
+fn children_focusables(menu: Entity, queries: &NavQueries) -> NonEmpty<Entity> {
+    let ret = children_focusables_helper(menu, queries);
     assert!(
         !ret.is_empty(),
-        "A NavFence MUST AT LEAST HAVE ONE Focusable child, {:?} has none",
-        nav_fence
+        "A NavMenu MUST AT LEAST HAVE ONE Focusable child, {:?} has none",
+        menu
     );
     NonEmpty::try_from(ret).unwrap()
 }
 
-fn children_focusables_helper(nav_fence: Entity, queries: &NavQueries) -> Vec<Entity> {
-    match queries.children.get(nav_fence).ok() {
+fn children_focusables_helper(menu: Entity, queries: &NavQueries) -> Vec<Entity> {
+    match queries.children.get(menu).ok() {
         Some(direct_children) => {
             let focusables = direct_children
                 .iter()
@@ -498,7 +523,7 @@ fn children_focusables_helper(nav_fence: Entity, queries: &NavQueries) -> Vec<En
             let transitive_focusables = direct_children
                 .iter()
                 .filter(|e| queries.focusables.get(**e).is_err())
-                .filter(|e| queries.nav_fences.get(**e).is_err())
+                .filter(|e| queries.menus.get(**e).is_err())
                 .flat_map(|e| children_focusables_helper(*e, queries));
             focusables.chain(transitive_focusables).collect()
         }
@@ -552,15 +577,15 @@ fn trim_common_tail<T: PartialEq>(v1: &mut NonEmpty<T>, v2: &mut NonEmpty<T>) {
 fn root_path(mut from: Entity, queries: &NavQueries) -> NonEmpty<Entity> {
     let mut ret = NonEmpty::new(from);
     loop {
-        from = match parent_nav_fence(from, queries) {
+        from = match parent_menu(from, queries) {
             // purely personal preference over deeply nested pattern match
-            Some((_, fence)) if fence.focus_parent.is_some() => fence.focus_parent.unwrap(),
+            Some((_, menu)) if menu.focus_parent.is_some() => menu.focus_parent.unwrap(),
             _ => return ret,
         };
         assert!(
             !ret.contains(&from),
             "Navigation graph cycle detected! This panic has prevented a stack \
-            overflow, please check usages of `NavFence::reachable_from`"
+            overflow, please check usages of `NavMenu::reachable_from`"
         );
         ret.push(from);
     }
@@ -568,12 +593,12 @@ fn root_path(mut from: Entity, queries: &NavQueries) -> NonEmpty<Entity> {
 
 fn resolve_index(
     from: usize,
-    loops: bool,
-    direction: MenuDirection,
+    cycles: bool,
+    direction: ScopeDirection,
     max_value: usize,
 ) -> Option<usize> {
-    use MenuDirection::*;
-    match (direction, loops, from) {
+    use ScopeDirection::*;
+    match (direction, cycles, from) {
         (Previous, true, 0) => Some(max_value),
         (Previous, true, from) => Some(from - 1),
         (Previous, false, 0) => None,
@@ -584,6 +609,10 @@ fn resolve_index(
     }
 }
 
+/// The navigation plugin
+///
+/// Add it to your app with `.add_plugin(NavigationPlugin)` and send
+/// [`NavRequest`]s to move focus within declared [`Focusable`] entities.
 pub struct NavigationPlugin;
 impl Plugin for NavigationPlugin {
     fn build(&self, app: &mut App) {


### PR DESCRIPTION
* Rename all the things!
    * `NavFence` ⇒ `NavMenu`
    * `loop`, `looping` ⇒ `cycle`, `cycling`
    * `MenuMove` ⇒ `ScopeMove`
    * `sequence`, sequence menu ⇒ `scope`, scope menu
    * `NavEvent::Caught` ⇒ `NavEvent::NoChanges`
* Add the `Focusable::state` method
* Document a bunch more things
* Re-export the `non_empty_vec::NonEmpty` struct so that it's possible
  to read content from `NavEvent`s without adding an explicit dependency
  to `non-empty-vec`